### PR TITLE
Fix mobile menu clipping and enlarge logo

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -890,8 +890,8 @@ footer p {
     }
     
     .cornerstone img {
-        height: 30px;
-        width: 50px;
+        height: 45px;
+        width: 75px;
     }
     
     .main-nav {
@@ -900,7 +900,7 @@ footer p {
         gap: 4px;
         width: 100%;
         flex: 1 0 100%;
-        overflow-x: auto;
+        overflow: visible;
         order: 3;
         margin-top: 4px;
     }


### PR DESCRIPTION
## Summary
- prevent dropdown cut off by showing overflow on small screens
- bump cornerstone logo size for better visibility on mobile

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687711eff30883308971e1a0ae1121fb