### PR TITLE
Fix farm section layout and offerings

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Online Ordering & Pickup:
             -Blueberry Starters (Bluecrop, Elliot, Duke)
             -Sweet Potato Starters (Kejora, Stokes, Beauregard)
 
-        -Animal Products:
+        -Garden & Livestock:
             -BSF Larvae (Live) (500, 1000)
             -BSF Larvae (Dry) (2lb, 5lb, 10lb)
             -Home Grown Animal feed (30% apple pomace, 30% dry duckweed, 30% BSF larvae) (25lb bag)

--- a/css/main.css
+++ b/css/main.css
@@ -480,7 +480,7 @@ main {
 .slideshow-container {
     max-width: 1100px;
     position: relative;
-    margin: 40px auto;
+    margin: 20px auto;
     background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
     border-radius: 24px;
     overflow: hidden;
@@ -626,9 +626,9 @@ main {
 }
 
 .farm-details {
-    max-width: 1100px;
-    margin: 60px auto;
-    padding: 60px;
+    max-width: 900px;
+    margin: 10px auto;
+    padding: 30px;
     background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
     border-radius: 24px;
     box-shadow: 0 20px 40px rgba(0,0,0,0.1);
@@ -684,6 +684,7 @@ main {
     color: #2d7d3f;
     font-weight: 600;
 }
+
 
 footer {
     background: linear-gradient(135deg, #1a202c 0%, #2d3748 100%);
@@ -1020,7 +1021,7 @@ footer p {
     }
     
     .slideshow-container {
-        margin: 15px 5px;
+        margin: 5px;
     }
     
     .mySlides img {
@@ -1056,8 +1057,8 @@ footer p {
     }
     
     .farm-details {
-        padding: 20px;
-        margin: 30px 5px;
+        padding: 10px;
+        margin: 10px 5px;
     }
     
     .farm-details h2 {
@@ -1130,6 +1131,7 @@ footer p {
         font-size: 0.75em;
         margin-bottom: 10px;
     }
+
 }
 
 /* Tablet Portrait */
@@ -1199,7 +1201,7 @@ footer p {
     }
     
     .slideshow-container {
-        margin: 20px 10px;
+        margin: 10px 10px;
     }
     
     .mySlides img {
@@ -1231,8 +1233,8 @@ footer p {
     }
     
     .farm-details {
-        padding: 30px;
-        margin: 40px 10px;
+        padding: 20px;
+        margin: 15px 10px;
     }
     
     .farm-details h2 {
@@ -1242,7 +1244,8 @@ footer p {
     .farm-details p {
         font-size: 1.1em;
     }
-    
+
+
     .bulk-order-banner {
         margin: 0 10px 20px;
         padding: 0 15px;

--- a/index.html
+++ b/index.html
@@ -77,6 +77,14 @@
             <p><b>What we grow:</b> Apples, Blueberries, Strawberries, Blackberries</p>
             <p>We offer pick-your-own for many of our fruits, and we also sell and deliver bulk orders locally.</p>
         </section>
+
+        <section class="farm-details">
+            <h2>Our Offerings</h2>
+            <p>We offer pick-your-own for many of our fruits, check out the <a href="pages/pick-your-own.html">Pick Your Own</a> page to find out more.</p>
+            <p>Our web store is where you can place online and pickup orders (with an option for bulk orders &amp; local delivery).</p>
+            <p><b>Roadside Stand:</b> Our roadside stand is regularly stocked with some of our pickup-only non-produce items like our dried BSF larvae, bags of compost, and animal feed. Just stop by and use our self checkout.</p>
+            <p>We don't just grow berries here! We also have a variety of plant starters (sweet potato, strawberry, blueberry) as well as garden and livestock products available at our store page. Just submit a pickup order.</p>
+        </section>
     </main>
 
     <footer>

--- a/pages/online-pickup.html
+++ b/pages/online-pickup.html
@@ -290,7 +290,7 @@
             </section>
 
             <section class="product-category">
-                <h2>Animal Products</h2>
+                <h2>Garden &amp; Livestock</h2>
                 <div class="product-grid">
                     <div class="product-card">
                         <img src="../assets/images/farm_logo.png" alt="BSF Larvae" class="product-image">


### PR DESCRIPTION
## Summary
- reduce slideshow and farm section spacing
- shrink farm details width and padding
- move index summary text into a new **Our Offerings** section

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68772230b44483309a3e45e2f6e0a141