### PR TITLE
Add cider product and reorganize landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,15 +75,23 @@
             <h2>Our Farm</h2>
             <p><b>Address:</b> 7604 Beach Rd, Wadsworth, OH</p>
             <p><b>What we grow:</b> Apples, Blueberries, Strawberries, Blackberries</p>
+            <p>Come pick your own fruit, visit our roadside stand, or shop online. You can also text or message us on Facebook anytime to arrange a pickup.</p>
         </section>
 
+        <section class="farm-details">
+            <h2>Pick Your Own</h2>
+            <p>We host pick-your-own apples, blueberries, blackberries, and strawberries as they ripen. PYO typically runs Thursday and Friday evenings from 5&ndash;8&nbsp;pm and weekends from 9&nbsp;am&ndash;8&nbsp;pm. Check our <a href="https://www.facebook.com/profile.php?id=61578190239493" target="_blank">Facebook page</a> or the <a href="pages/produce-variety-ripening-schedule.html">ripening schedule</a> for dates.</p>
+        </section>
 
         <section class="farm-details">
-            <h2>Our Offerings</h2>
-            <p>We offer pick-your-own for many of our fruits, check out the <a href="pages/pick-your-own.html">Pick Your Own</a> page to find out more.</p>
-            <p><b>Webstore:</b> <a href="pages/online-pickup.html">Our web store</a> is where you can place online and pickup orders (with an option for bulk orders &amp; local delivery).</p>
-            <p><b>Roadside Stand:</b> Our roadside stand is regularly stocked with some of our pickup-only non-produce items like our dried BSF larvae, bags of compost, and animal feed. Just stop by and use our self checkout.</p>
-            <p>We don't just grow berries here! We also have a variety of plant starters (sweet potato, strawberry, blueberry) as well as garden and livestock products available at our store page. Just submit a pickup order.</p>
+            <h2>Roadside Stand</h2>
+            <p>Our roadside stand is stocked with the things we produce here. Freezers hold frozen berries, and an order shelf lets you pick up anything you've purchased online. You'll also find our dried BSF larvae, compost, and animal feed for self-service checkout.</p>
+        </section>
+
+        <section class="farm-details">
+            <h2>Web Store</h2>
+            <p><a href="pages/online-pickup.html">Our web store</a> offers fresh and frozen produce, honey, plant starters and other garden and livestock items for pickup. Bulk orders and local delivery are available.</p>
+            <p>We don't just grow berries&mdash;check the store for everything we offer and submit a pickup order.</p>
         </section>
     </main>
 

--- a/pages/online-pickup.html
+++ b/pages/online-pickup.html
@@ -125,6 +125,24 @@
                         <div class="price-display" id="strawberries-price">$7.00</div>
                         <button class="add-to-cart" onclick="addToCart('strawberries')">Add to Cart</button>
                     </div>
+
+                    <div class="product-card">
+                        <img src="../assets/images/farm_logo.png" alt="Apple Cider" class="product-image">
+                        <h3>Apple Cider</h3>
+                        <p class="product-description">Fresh-pressed cider from our apples</p>
+                        <div class="quantity-selector">
+                            <div class="quantity-option">
+                                <input type="radio" id="cider-1gal" name="cider-qty" value="1gal-5.00" checked>
+                                <label for="cider-1gal">1 gal</label>
+                            </div>
+                            <div class="quantity-option">
+                                <input type="radio" id="cider-halfgal" name="cider-qty" value="halfgal-3.00">
+                                <label for="cider-halfgal">1/2 gal</label>
+                            </div>
+                        </div>
+                        <div class="price-display" id="cider-price">$5.00</div>
+                        <button class="add-to-cart" onclick="addToCart('cider')">Add to Cart</button>
+                    </div>
                 </div>
             </section>
 


### PR DESCRIPTION
## Summary
- add Apple Cider to the Fresh Produce list
- reorganize `index.html` landing page with new Pick Your Own, Roadside Stand, and Web Store sections
- mention purchase options in Our Farm section and drop old Our Offerings section