### PR TITLE
Add availability indicator to product cards

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -817,6 +817,25 @@ footer a:hover {
     background: linear-gradient(135deg, #2d7d3f 0%, #1e5631 100%);
 }
 
+.availability {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.7em;
+    font-weight: 600;
+    color: #fff;
+}
+
+.availability.available {
+    background-color: #2d7d3f;
+}
+
+.availability.out-of-stock {
+    background-color: #c53030;
+}
+
 .product-card:hover {
     transform: translateY(-5px);
     box-shadow: 0 15px 40px rgba(0, 0, 0, 0.15);

--- a/pages/online-pickup.html
+++ b/pages/online-pickup.html
@@ -63,6 +63,7 @@
                 <h2>Fresh Produce (Pickup Only)</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Fresh Blueberries" class="product-image">
                         <h3>Blueberries</h3>
                         <p class="product-description">Fresh, juicy blueberries perfect for snacking</p>
@@ -85,6 +86,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Fresh Apples" class="product-image">
                         <h3>Apples</h3>
                         <p class="product-description">Crisp apples, perfect for eating fresh</p>
@@ -99,6 +101,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Fresh Blackberries" class="product-image">
                         <h3>Blackberries</h3>
                         <p class="product-description">Sweet, dark blackberries full of flavor</p>
@@ -113,6 +116,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Fresh Strawberries" class="product-image">
                         <h3>Strawberries</h3>
                         <p class="product-description">Bright red, juicy strawberries</p>
@@ -127,6 +131,7 @@
                     </div>
 
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Apple Cider" class="product-image">
                         <h3>Apple Cider</h3>
                         <p class="product-description">Fresh-pressed cider from our apples</p>
@@ -150,6 +155,7 @@
                 <h2>Frozen Produce</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Frozen Blueberries" class="product-image">
                         <h3>Frozen Blueberries</h3>
                         <p class="product-description">Farm-fresh blueberries, frozen at peak ripeness</p>
@@ -164,6 +170,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Frozen Blackberries" class="product-image">
                         <h3>Frozen Blackberries</h3>
                         <p class="product-description">Sweet frozen blackberries, perfect for smoothies</p>
@@ -178,6 +185,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Frozen Strawberries" class="product-image">
                         <h3>Frozen Strawberries</h3>
                         <p class="product-description">Farm-fresh strawberries, frozen for year-round enjoyment</p>
@@ -197,6 +205,7 @@
                 <h2>Honey</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Clover Honey" class="product-image">
                         <h3>Clover Honey</h3>
                         <p class="product-description">Pure, golden clover honey from our hives</p>
@@ -211,6 +220,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Apple Blossom Honey" class="product-image">
                         <h3>Apple Blossom Honey</h3>
                         <p class="product-description">Light, floral honey from apple blossoms</p>
@@ -225,6 +235,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Blueberry Blossom Honey" class="product-image">
                         <h3>Blueberry Blossom Honey</h3>
                         <p class="product-description">Rich, fruity honey from blueberry blossoms</p>
@@ -244,6 +255,7 @@
                 <h2>Plant Starters</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Strawberry Plants" class="product-image">
                         <h3>Strawberry Starters</h3>
                         <p class="product-description">Healthy strawberry plants, 10 per order</p>
@@ -262,6 +274,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Blueberry Plants" class="product-image">
                         <h3>Blueberry Starters</h3>
                         <p class="product-description">Young blueberry bushes, 1 per order</p>
@@ -284,6 +297,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Sweet Potato Slips" class="product-image">
                         <h3>Sweet Potato Starters</h3>
                         <p class="product-description">Fresh sweet potato slips, 10 per order</p>
@@ -311,6 +325,7 @@
                 <h2>Garden &amp; Livestock</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="BSF Larvae" class="product-image">
                         <h3>BSF Larvae (Live)</h3>
                         <p class="product-description">Live black soldier fly larvae for animal feed</p>
@@ -329,6 +344,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Dried BSF Larvae" class="product-image">
                         <h3>BSF Larvae (Dried)</h3>
                         <p class="product-description">Dried black soldier fly larvae, high protein feed</p>
@@ -351,6 +367,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Animal Feed" class="product-image">
                         <h3>Home Grown Animal Feed</h3>
                         <p class="product-description">Blend of pomace, duckweed, and BSF larvae</p>
@@ -365,6 +382,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Compost" class="product-image">
                         <h3>Organic Compost Fertilizer</h3>
                         <p class="product-description">Rich, organic compost for healthy plants</p>


### PR DESCRIPTION
## Summary
- add CSS styles for availability tags
- show `Available` tag on each product card in the online pickup page
