### PR TITLE
Adjust nav colors for black shop button

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -24,7 +24,7 @@ body {
 }
 
 .nav-top {
-    background: #2d7d3f;
+    background: #111;
     display: flex;
     align-items: center;
     padding: 8px 40px 8px 200px;
@@ -218,8 +218,8 @@ body {
 }
 
 .shop-button {
-    background: linear-gradient(135deg, #2d7d3f 0%, #1e5631 100%);
-    color: white;
+    background: #000;
+    color: #fff;
     padding: 12px 20px;
     border: none;
     border-radius: 25px;
@@ -227,11 +227,11 @@ body {
     font-size: 15px;
     font-weight: 700;
     font-family: 'Inter', sans-serif;
-    transition: all 0.3s ease;
+    transition: background 0.3s ease, transform 0.2s ease;
     display: flex;
     align-items: center;
     gap: 8px;
-    box-shadow: 0 4px 15px rgba(45, 125, 63, 0.3);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
     position: relative;
     overflow: hidden;
     text-transform: uppercase;
@@ -254,9 +254,9 @@ body {
 }
 
 .shop-button:hover {
-    background: linear-gradient(135deg, #1e5631 0%, #2d7d3f 100%);
+    background: #222;
     transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(45, 125, 63, 0.4);
+    box-shadow: 0 8px 25px rgba(0, 0, 0, 0.4);
 }
 
 .shop-button:active {
@@ -264,20 +264,20 @@ body {
 }
 
 .shop-button.prominent {
-    background: linear-gradient(135deg, #4a7c59 0%, #2d7d3f 100%);
-    box-shadow: 0 6px 20px rgba(45, 125, 63, 0.4);
+    background: #000;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
     font-weight: 700;
-    border: 2px solid rgba(255, 255, 255, 0.1);
+    border: 2px solid #fff;
 }
 
 .shop-button.prominent:hover {
-    background: linear-gradient(135deg, #2d7d3f 0%, #1e5631 100%);
-    box-shadow: 0 10px 30px rgba(45, 125, 63, 0.5);
-    border-color: rgba(255, 255, 255, 0.2);
+    background: #111;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+    border-color: #eee;
 }
 
 .nav-bottom {
-    background: linear-gradient(135deg, #3182ce 0%, #2c5282 100%);
+    background: #222;
     padding: 6px 40px 6px 200px;
     display: flex;
     justify-content: flex-start;
@@ -815,6 +815,25 @@ footer a:hover {
     right: 0;
     height: 4px;
     background: linear-gradient(135deg, #2d7d3f 0%, #1e5631 100%);
+}
+
+.availability {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    font-size: 0.7em;
+    font-weight: 600;
+    color: #fff;
+}
+
+.availability.available {
+    background-color: #2d7d3f;
+}
+
+.availability.out-of-stock {
+    background-color: #c53030;
 }
 
 .product-card:hover {

--- a/pages/online-pickup.html
+++ b/pages/online-pickup.html
@@ -63,6 +63,7 @@
                 <h2>Fresh Produce (Pickup Only)</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Fresh Blueberries" class="product-image">
                         <h3>Blueberries</h3>
                         <p class="product-description">Fresh, juicy blueberries perfect for snacking</p>
@@ -85,6 +86,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Fresh Apples" class="product-image">
                         <h3>Apples</h3>
                         <p class="product-description">Crisp apples, perfect for eating fresh</p>
@@ -99,6 +101,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Fresh Blackberries" class="product-image">
                         <h3>Blackberries</h3>
                         <p class="product-description">Sweet, dark blackberries full of flavor</p>
@@ -113,6 +116,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Fresh Strawberries" class="product-image">
                         <h3>Strawberries</h3>
                         <p class="product-description">Bright red, juicy strawberries</p>
@@ -127,6 +131,7 @@
                     </div>
 
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Apple Cider" class="product-image">
                         <h3>Apple Cider</h3>
                         <p class="product-description">Fresh-pressed cider from our apples</p>
@@ -150,6 +155,7 @@
                 <h2>Frozen Produce</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Frozen Blueberries" class="product-image">
                         <h3>Frozen Blueberries</h3>
                         <p class="product-description">Farm-fresh blueberries, frozen at peak ripeness</p>
@@ -164,6 +170,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Frozen Blackberries" class="product-image">
                         <h3>Frozen Blackberries</h3>
                         <p class="product-description">Sweet frozen blackberries, perfect for smoothies</p>
@@ -178,6 +185,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Frozen Strawberries" class="product-image">
                         <h3>Frozen Strawberries</h3>
                         <p class="product-description">Farm-fresh strawberries, frozen for year-round enjoyment</p>
@@ -197,6 +205,7 @@
                 <h2>Honey</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Clover Honey" class="product-image">
                         <h3>Clover Honey</h3>
                         <p class="product-description">Pure, golden clover honey from our hives</p>
@@ -211,6 +220,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Apple Blossom Honey" class="product-image">
                         <h3>Apple Blossom Honey</h3>
                         <p class="product-description">Light, floral honey from apple blossoms</p>
@@ -225,6 +235,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Blueberry Blossom Honey" class="product-image">
                         <h3>Blueberry Blossom Honey</h3>
                         <p class="product-description">Rich, fruity honey from blueberry blossoms</p>
@@ -244,6 +255,7 @@
                 <h2>Plant Starters</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Strawberry Plants" class="product-image">
                         <h3>Strawberry Starters</h3>
                         <p class="product-description">Healthy strawberry plants, 10 per order</p>
@@ -262,6 +274,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Blueberry Plants" class="product-image">
                         <h3>Blueberry Starters</h3>
                         <p class="product-description">Young blueberry bushes, 1 per order</p>
@@ -284,6 +297,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Sweet Potato Slips" class="product-image">
                         <h3>Sweet Potato Starters</h3>
                         <p class="product-description">Fresh sweet potato slips, 10 per order</p>
@@ -311,6 +325,7 @@
                 <h2>Garden &amp; Livestock</h2>
                 <div class="product-grid">
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="BSF Larvae" class="product-image">
                         <h3>BSF Larvae (Live)</h3>
                         <p class="product-description">Live black soldier fly larvae for animal feed</p>
@@ -329,6 +344,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Dried BSF Larvae" class="product-image">
                         <h3>BSF Larvae (Dried)</h3>
                         <p class="product-description">Dried black soldier fly larvae, high protein feed</p>
@@ -351,6 +367,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Animal Feed" class="product-image">
                         <h3>Home Grown Animal Feed</h3>
                         <p class="product-description">Blend of pomace, duckweed, and BSF larvae</p>
@@ -365,6 +382,7 @@
                     </div>
                     
                     <div class="product-card">
+                        <div class="availability available">Available</div>
                         <img src="../assets/images/farm_logo.png" alt="Compost" class="product-image">
                         <h3>Organic Compost Fertilizer</h3>
                         <p class="product-description">Rich, organic compost for healthy plants</p>


### PR DESCRIPTION
## Summary
- switch nav-top to dark gray
- use a matching dark gray for nav-bottom
- keep sleek black shop button style

## Testing
- `tidy -errors -q index.html` *(with warnings about empty spans)*
- `tidy -errors -q pages/online-pickup.html`

------
https://chatgpt.com/codex/tasks/task_e_6878515488b8833082a8c653c13ad6d8